### PR TITLE
Fix the output file having spurious null bytes

### DIFF
--- a/src/main/java/jarekr/jsq/Lib.java
+++ b/src/main/java/jarekr/jsq/Lib.java
@@ -1,7 +1,6 @@
 package jarekr.jsq;
 
 import java.io.*;
-import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
Using a BufferedWriter was leaving null bytes behind when extracting (-x) a squished file and writing to a new file. 

Convert all "diagnostic" output to stderr so it's easier to get just the uncompressed output via bash redirection (for example).

